### PR TITLE
Update build files to use plugin 2.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+.intellijPlatform
 
 ### IntelliJ IDEA ###
 .idea/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.9.25"
-    id("org.jetbrains.intellij") version "1.17.4"
+    id("org.jetbrains.intellij.platform") version "2.3.0"
 }
 
 group = "dev.gorokhov"
@@ -9,30 +9,31 @@ version = "1.2.0"
 
 repositories {
     mavenCentral()
+	intellijPlatform {
+		defaultRepositories()
+		jetbrainsRuntime()
+  }
 }
 
-// Configure Gradle IntelliJ Plugin
-// Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
-intellij {
-    version.set("2024.1.7")
-    type.set("IC") // Target IDE Platform
-
-    plugins.set(listOf(/* Plugin Dependencies */))
+dependencies {
+  intellijPlatform {
+    intellijIdeaCommunity("2024.3.4")
+  }
 }
+
 
 tasks {
     // Set the JVM compatibility versions
     withType<JavaCompile> {
-        sourceCompatibility = "17"
-        targetCompatibility = "17"
+        sourceCompatibility = "21"
+        targetCompatibility = "21"
     }
     withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
+        kotlinOptions.jvmTarget = "21"
     }
 
     patchPluginXml {
-        sinceBuild.set("241")
-        untilBuild.set("243.*")
+        sinceBuild.set("243")
     }
 
     signPlugin {


### PR DESCRIPTION
Migrating from plugin 1.x to 2.x

https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-migration.html

Might make the plugin unusable on older versions of the intellij editors?

Closes #1, #2
