### PR TITLE
Match caret height to intellij default caret

### DIFF
--- a/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretRenderer.kt
+++ b/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretRenderer.kt
@@ -45,18 +45,18 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
                 SmoothCaretSettings.CaretStyle.BLOCK -> {
                     g2d.fillRect(
                         currentX.toInt(),
-                        currentY.toInt(),
+                        currentY.toInt() + settings.caretHeightMargins,
                         settings.caretWidth,
-                        lineHeight
+                        lineHeight - settings.caretHeightMargins * 2
                     )
                 }
 
                 SmoothCaretSettings.CaretStyle.LINE -> {
                     g2d.fillRect(
                         currentX.toInt(),
-                        currentY.toInt(),
+                        currentY.toInt() + settings.caretHeightMargins,
                         settings.caretWidth,
-                        lineHeight
+                        lineHeight - settings.caretHeightMargins * 2
                     )
                 }
 

--- a/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretSettings.kt
+++ b/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretSettings.kt
@@ -8,4 +8,5 @@ class SmoothCaretSettings {
     var caretWidth: Int = 2
     var caretStyle: CaretStyle = CaretStyle.LINE
     var caretColor: String = "CARET_COLOR"
+    var caretHeightMargins: Int = 2
 }


### PR DESCRIPTION
Add a slight margin to the caret height to match it to intellij caret height (at least in pycharm)

![Screenshot 2025-03-17 111705](https://github.com/user-attachments/assets/8d58b16f-9449-402c-b225-d69ab9a36e5b)

Closes #5

