### PR TITLE
Do not draw the cursor in an unfocused editor

### DIFF
--- a/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretRenderer.kt
+++ b/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretRenderer.kt
@@ -19,6 +19,8 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
     override fun paint(editor: Editor, highlighter: RangeHighlighter, g: Graphics) {
         if (!settings.isEnabled) return
 
+        if (!editor.contentComponent.hasFocus()) return
+
         // Reset position if editor changed
         if (lastEditor != editor) {
             lastEditor = editor


### PR DESCRIPTION
Avoid drawing the cursor when an editor goes out of focus. Solves https://github.com/TheTeaParty/intellij-smooth-caret/issues/11