### PR TITLE
More accurate caret placement and ideavim support

### DIFF
--- a/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretRenderer.kt
+++ b/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretRenderer.kt
@@ -8,8 +8,10 @@ import java.awt.Graphics
 import java.awt.Graphics2D
 import java.awt.GraphicsEnvironment
 import java.awt.RenderingHints
+import java.awt.geom.Point2D
 import javax.swing.Timer
 import kotlin.math.abs
+import kotlin.math.round
 import kotlin.math.sin
 
 class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHighlighterRenderer {
@@ -57,13 +59,13 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
         var anyMoving = false
 
         allCarets.forEach { caret ->
-            val point = editor.visualPositionToXY(caret.visualPosition)
+            val point = editor.visualPositionToPoint2D(caret.visualPosition)
             val caretPos = caretPositions.getOrPut(caret) {
                 CaretPosition(
-                    currentX = point.x.toDouble(),
-                    currentY = point.y.toDouble(),
-                    targetX = point.x.toDouble(),
-                    targetY = point.y.toDouble()
+                    currentX = point.x,
+                    currentY = point.y,
+                    targetX = point.x,
+                    targetY = point.y
                 )
             }
 
@@ -71,8 +73,8 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
                 resetCaretPosition(caretPos, point)
             }
 
-            caretPos.targetX = point.x.toDouble()
-            caretPos.targetY = point.y.toDouble()
+            caretPos.targetX = point.x
+            caretPos.targetY = point.y
 
             val isMoving =
                 abs(caretPos.targetX - caretPos.currentX) > 0.01 || abs(caretPos.targetY - caretPos.currentY) > 0.01
@@ -120,8 +122,8 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
             val caretPos = caretPositions[caret] ?: return@forEach
 
             if (caretPos.currentX.isFinite() && caretPos.currentY.isFinite()) {
-                val caretX = caretPos.currentX.toInt()
-                val caretY = caretPos.currentY.toInt()
+                val caretX = round(caretPos.currentX).toInt()
+                val caretY = round(caretPos.currentY).toInt()
                 val scaledHeight = (caretHeight * blinkValue.scaleY).toInt()
                 val yOffset = if (blinkValue.scaleY < 1.0f) {
                     settings.caretHeightMargins + (caretHeight - scaledHeight) / 2
@@ -244,21 +246,21 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
         caretPositions.clear()
         val allCarets = editor.caretModel.allCarets
         allCarets.forEach { caret ->
-            val point = editor.visualPositionToXY(caret.visualPosition)
+            val point = editor.visualPositionToPoint2D(caret.visualPosition)
             val caretPos = CaretPosition(
-                currentX = point.x.toDouble(),
-                currentY = point.y.toDouble(),
-                targetX = point.x.toDouble(),
-                targetY = point.y.toDouble()
+                currentX = point.x,
+                currentY = point.y,
+                targetX = point.x,
+                targetY = point.y
             )
             caretPositions[caret] = caretPos
         }
         blinkStartTime = System.currentTimeMillis()
     }
 
-    private fun resetCaretPosition(caretPos: CaretPosition, point: java.awt.Point) {
-        caretPos.currentX = point.x.toDouble()
-        caretPos.currentY = point.y.toDouble()
+    private fun resetCaretPosition(caretPos: CaretPosition, point: Point2D) {
+        caretPos.currentX = point.x
+        caretPos.currentY = point.y
         caretPos.targetX = caretPos.currentX
         caretPos.targetY = caretPos.currentY
     }
@@ -305,7 +307,7 @@ class SmoothCaretRenderer(private val settings: SmoothCaretSettings) : CustomHig
                         val dx = caretPos.targetX - caretPos.currentX
                         val dy = caretPos.targetY - caretPos.currentY
 
-                        if (abs(dx) > 0.01 || abs(dy) > 0.01) {
+                        if (abs(dx) > 0 || abs(dy) > 0.01) {
                             val speedFactor = if (settings.adaptiveSpeed) {
                                 when {
                                     abs(dx) > cachedCharWidth * 2 -> settings.maxCatchupSpeed

--- a/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretSettings.kt
+++ b/src/main/kotlin/dev/gorokhov/smoothcaret/SmoothCaretSettings.kt
@@ -10,15 +10,11 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 )
 class SmoothCaretSettings : PersistentStateComponent<SmoothCaretSettings> {
 
-    enum class CaretStyle { BLOCK, LINE, UNDERSCORE }
-
     enum class BlinkingStyle { BLINK, SMOOTH, PHASE, EXPAND, SOLID }
 
     var isEnabled: Boolean = true
     var replaceDefaultCaret: Boolean = true
     var caretWidth: Int = 2
-    var caretStyle: CaretStyle = CaretStyle.LINE
-    var caretColor: String = "CARET_COLOR"
 
     var blinkInterval: Int = 850
     var blinkingStyle: BlinkingStyle = BlinkingStyle.BLINK
@@ -35,7 +31,6 @@ class SmoothCaretSettings : PersistentStateComponent<SmoothCaretSettings> {
         isEnabled = true
         blinkInterval = 850
         blinkingStyle = BlinkingStyle.BLINK
-        caretStyle = CaretStyle.LINE
         caretWidth = 2
         caretHeightMargins = 2
         smoothness = 0.15f
@@ -51,4 +46,3 @@ class SmoothCaretSettings : PersistentStateComponent<SmoothCaretSettings> {
         XmlSerializerUtil.copyBean(state, this)
     }
 }
-


### PR DESCRIPTION
Made these 2 changes as a single PR because the block shape is #literallyunusable when the movement is off (it's _much_ more obvious when you have a block caret).

## More accurate caret movement:

| | move left then right | move right then left |
|--------|--------|--------|
| before | <img width="20" height="35" alt="image" src="https://github.com/user-attachments/assets/1175dc28-5a57-497f-a294-2e9aaed93cc9" /> | <img width="20" height="35" alt="image" src="https://github.com/user-attachments/assets/9cfd6dde-ffde-43cb-b803-cbc14e4fb165" /> |
| after | <img width="20" height="35" alt="image" src="https://github.com/user-attachments/assets/0a39466b-f54c-4e91-8249-b30bccaba3ae" /> | <img width="20" height="35" alt="image" src="https://github.com/user-attachments/assets/03c6c4c6-e603-4d54-8cb9-92fd66af3e07" /> |

Note how there's a tiny gap between the cursor and the left side of the `P` when moving left then right, and a tiny bit of overlap between the cursor and the `P` when moving right then left before. In the after, the cursor is consistently placed regardless of animation direction.

## Use editor caret attributes to determine caret shape:
Makes Ideavim work:

https://github.com/user-attachments/assets/9855d851-1c22-4614-b778-4bef1db837f5

https://github.com/user-attachments/assets/021511d8-1a41-4099-bc16-b881b1f45a9f